### PR TITLE
Security/hide key

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,13 +1,18 @@
+from dotenv import load_dotenv
 import os
+
+load_dotenv()
 
 class Config:
     # Secret key for session logic
-    SECRET_KEY = os.getenv('SECRET_KEY') or 'dev-secret-key' # swap for real env var later
+    SECRET_KEY = os.getenv('SECRET_KEY')
+
+    #Flag error if missing secret key environment var:
+    if not SECRET_KEY:
+        raise Exception("SECRET_KEY is not defined, check if you have the .env file!")
     # Configure the database URI and initialize the database
     SQLALCHEMY_DATABASE_URI = 'sqlite:///app.db'
 
 
-    # Moved from app.py but 
-    # "it is in general a good practice to set configuration from environment variables, 
-    # and provide a fallback value when the environment does not define the variable" - From Flask Mega Tutorial (my saviour)
-    # Maybe something to think about when handling databases (Thanks flask mega tutorial)
+    # It's generally bad practice to hardcode a key even on the chance that environment variable is inaccessable.
+    # If a SECRET_KEY can't be retrieved from env, the app should raise an error instead.

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ Flask-WTF==1.2.2
 flask-login==0.6.3
 Werkzeug==3.1.8
 itsdangerous==2.2.0
+python-dotenv==1.2.2


### PR DESCRIPTION
closes #84 

# Features

- Removes hardcoded secret key in config.py. 
- Added python-dotenv package to requirements.txt. **Requires pip install, would recommend just pip installing requirements.txt since its easier**
- Created new .env with secret key (Not committed; Will be distributed through private channels)
- Raise error if no secret key is found in environment variables

Note: if you want to really use a hardcoded key rather than the env var, just add:
```python
or 'your-key'
```
to SECRET_KEY variable. I would not recommend doing so (or at least don't push it into main if you do) for security reasons