### PR TITLE
Add basic model tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ flask-login==0.6.3
 Werkzeug==3.1.8
 itsdangerous==2.2.0
 python-dotenv==1.2.2
+pytest==9.0.2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,53 @@
+import os
+from datetime import datetime, timezone
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+
+from app import app, db
+from app.models import Event, User
+
+
+def setup_function():
+    app.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+    app.app_context().push()
+    db.create_all()
+
+
+def teardown_function():
+    db.session.remove()
+    db.drop_all()
+
+
+def test_password_hashing_and_verification():
+    user = User(username="tester", email="tester@example.com")
+    user.password = "correct horse battery staple"
+
+    assert user.password_hash != "correct horse battery staple"
+    assert user.verify_password("correct horse battery staple")
+    assert not user.verify_password("wrong password")
+
+
+def test_event_to_dict_marks_naive_datetimes_as_utc():
+    user = User(username="owner", email="owner@example.com")
+    db.session.add(user)
+    db.session.commit()
+
+    event = Event(
+        title="Tutorial",
+        start_time=datetime(2026, 5, 1, 9, 0),
+        end_time=datetime(2026, 5, 1, 10, 0, tzinfo=timezone.utc),
+        user_id=user.id,
+    )
+    db.session.add(event)
+    db.session.commit()
+
+    data = event.to_dict()
+
+    assert data["title"] == "Tutorial"
+    assert data["username"] == "owner"
+    assert data["startTime"] == "2026-05-01T09:00:00+00:00"
+    assert data["endTime"] == "2026-05-01T10:00:00+00:00"


### PR DESCRIPTION
Adds a small pytest test suite covering core model behavior.\n\nChanges include:\n- password hashing and verification coverage for User\n- Event serialization coverage for UTC datetime output\n- pytest added to the Python requirements\n\nValidation:\n- PYTHONPATH=. pytest -q