### PR TITLE
Changed links to new links to github rep

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use the planning dir for plans
 1. Clone the project
 
    ```bash
-   git clone git@github.com:stoveup/AgileWeb2026.git
+   git clone git@github.com:CASync-dev/CASync.git
    cd AgileWeb2026
    ```
 

--- a/templates/loggedout/contact-us.html
+++ b/templates/loggedout/contact-us.html
@@ -16,7 +16,7 @@
           <div class="py-5">
             <a
               class="btn-primary"
-              href="https://github.com/stoveup/AgileWeb2026/issues"
+              href="https://github.com/CASync-dev/CASync/issues"
             >
               Issues
             </a>

--- a/templates/loggedout/log-out-layout.html
+++ b/templates/loggedout/log-out-layout.html
@@ -174,7 +174,7 @@
             <div class="">
               <br />
               <a
-                href="https://github.com/stoveup/AgileWeb2026"
+                href="https://github.com/CASync-dev/CASync"
                 class="text-1xl font-semibold text-nearwhite"
                 target="_blank"
               >
@@ -216,7 +216,7 @@
             <div class="px-6 max-sm:px-3">
               <a
                 id="github"
-                href="https://github.com/stoveup/AgileWeb2026"
+                href="https://github.com/CASync-dev/CASync"
                 class="text-nearwhite text-2xl"
                 target="_blank"
               >


### PR DESCRIPTION
Not too big of an issue but probably shouldnt rely too heavily on the redirects to this page.