### PR TITLE
Removed hardcoded SECRET KEY

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -5,7 +5,7 @@ load_dotenv()
 
 class Config:
     # Secret key for session logic
-    SECRET_KEY = os.getenv('SECRET_KEY') or 'DEV_KEY'
+    SECRET_KEY = os.getenv('SECRET_KEY')
 
     # Removed below so github actions can run the tests as well.
     #Flag error if missing secret key environment var:

--- a/app/config.py
+++ b/app/config.py
@@ -29,4 +29,5 @@ class TestConfig(Config):
 
     # Creates a non persistent database in the memory
     SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:' #'sqlite://' should also work but will stick to :memory for now
+    SECRET_KEY = 'DEV-TEST' # This is a secret key only used for testing.
     TESTING = True


### PR DESCRIPTION
Currently testing if selenium tests work without the secret key at all (highly doubt it)

If it fails, will add a hardcoded secret key for testconfig.