### PR TITLE
Run container as non-root appuser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,12 @@ RUN echo "==> [app] copying application source"
 COPY . .
 COPY --from=css-builder /app/static/css/output.css ./static/css/output.css
 
-RUN mkdir -p instance static/avatars \
+# Create an unprivileged runtime user and hand it the two directories the app
+# writes to: instance/ (SQLite DB) and static/avatars/ (profile-picture uploads).
+# uid 10001 is fixed so a bind-mounted host volume can be chowned to match.
+RUN adduser -D -u 10001 appuser \
+ && mkdir -p instance static/avatars \
+ && chown -R appuser:appuser instance static/avatars \
  && echo "==> [app] runtime dirs ready" \
  && echo "==> [app] image build complete"
 
@@ -52,6 +57,10 @@ ENV FLASK_APP=app.py \
     GUNICORN_WORKERS=2 \
     GUNICORN_THREADS=4 \
     GUNICORN_TIMEOUT=60
+
+# Drop root: everything from here (including the CMD process) runs as appuser.
+# A container breakout lands as an unprivileged uid, not root.
+USER appuser
 
 # gthread worker class lets each worker handle multiple concurrent requests
 # (important when one slow iCal fetch would otherwise pin an entire sync

--- a/wsgi.py
+++ b/wsgi.py
@@ -5,9 +5,9 @@ from app.config import DeploymentConfig
 
 app = create_app(DeploymentConfig())
 
-# Two trusted hops in front of the container: the host nginx (which terminates
-# TLS and sets the original X-Forwarded-* headers) and Coolify's Traefik (which
-# appends itself). x_for=2 unwinds both so REMOTE_ADDR ends up as the real
-# client IP rather than nginx/Traefik. x_proto/x_host/x_prefix stay at 1 since
-# those aren't chained headers — only the last (Traefik) value matters.
-app.wsgi_app = ProxyFix(app.wsgi_app, x_for=2, x_proto=1, x_host=1, x_prefix=1)
+# One trusted hop in front of the container: Caddy, which terminates TLS and
+# sets X-Forwarded-*. x_for=1 takes the single client value Caddy appends so
+# REMOTE_ADDR is the real client IP; trusting more would let a client spoof its
+# IP via a forged X-Forwarded-For. x_proto/x_host/x_prefix stay at 1 — Caddy
+# sets each of those once.
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)


### PR DESCRIPTION
Add an unprivileged appuser (uid 10001) and switch to it before CMD so the gunicorn process no longer runs as root. Give appuser ownership of the directories the app writes to (instance/ for the SQLite DB, static/avatars/ for uploads) so a container breakout lands as an unprivileged uid.