### PR TITLE
Better error for empty iCal feeds

### DIFF
--- a/services/ical.py
+++ b/services/ical.py
@@ -8,6 +8,16 @@ from urllib.parse import urlparse # for URL parsing
 from app import db
 from app.models import Event, Calendar
 
+
+class IcalFeedError(Exception):
+    """
+    Raised when a feed is fetched successfully (HTTP 200, no network error) but
+    its content is unusable — e.g. the body is empty or exceeds the size limit.
+    Kept distinct from parser errors so the caller can surface a clear,
+    user-facing message instead of a raw icalendar traceback like
+    "Found no components where exactly one is required: b''".
+    """
+
 # Address categories we refuse to fetch from. Anything in these ranges could
 # point at internal services or cloud metadata endpoints (e.g. 169.254.169.254
 # on AWS/GCP), and is never a legitimate iCal feed host.
@@ -160,9 +170,16 @@ def fetch_ical_events(url):
         for chunk in response.iter_content(chunk_size=65536):
             received += len(chunk)
             if received > MAX_BYTES:
-                raise ValueError("The iCal feed is too large to process.")
+                raise IcalFeedError("The iCal feed is too large to process.")
             chunks.append(chunk)
         raw = b"".join(chunks)
+    # A 200 with an empty (or whitespace-only) body is the common symptom of a
+    # stale/expired CAS link. Catch it here with a clear message rather than
+    # letting the parser fail with an opaque "Found no components ... b''".
+    if not raw.strip():
+        raise IcalFeedError(
+            "The iCal feed was empty — check that the link is correct and still active."
+        )
     # Parse the iCal content using icalendar. This will give us a Calendar object with all the components.
     calendar = ICalendar.from_ical(raw)
 
@@ -297,9 +314,13 @@ def import_ical(url, user_id):
     # 2. Fetch iCal events from the URL
     try:
         ical_events = fetch_ical_events(url)
-    # We catch both network errors (requests.exceptions.RequestException) and parsing errors
+    # Network-layer failures (DNS, timeout, non-2xx, connection reset).
     except requests.exceptions.RequestException as e:
         return None, f"Could not fetch the iCal feed: {e}"
+    # Feed reached us but is unusable (empty / too large) — already a clear message.
+    except IcalFeedError as e:
+        return None, str(e)
+    # Anything else is a genuine parse failure on non-empty content.
     except Exception as e:
         return None, f"Could not parse the iCal feed: {e}"
     # If the feed was fetched successfully but contained no events, error

--- a/tests/unittests/test_ical.py
+++ b/tests/unittests/test_ical.py
@@ -1,10 +1,36 @@
 import unittest
+from unittest.mock import patch
+
 from app import create_app, db
 from app.config import TestConfig
 from app.models import User, Event, Calendar
+from services.ical import import_ical, fetch_ical_events, IcalFeedError
 
 SAMPLE_V1 = "https://raw.githubusercontent.com/LVaclav/test-icals/refs/heads/main/cal-v1.ics"
 SAMPLE_V2 = "https://raw.githubusercontent.com/LVaclav/test-icals/refs/heads/main/cal-v2.ics"
+
+
+class _FakeResponse:
+    """
+    Minimal stand-in for a streamed `requests` response, so the iCal fetch/error
+    tests don't touch the network. Mimics the context-manager + iter_content API
+    that fetch_ical_events uses.
+    """
+
+    def __init__(self, chunks=()):
+        self._chunks = list(chunks)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size=65536):
+        yield from self._chunks
 
 class CalTestCases(unittest.TestCase):
     def setUp(self):
@@ -149,3 +175,53 @@ class CalTestCases(unittest.TestCase):
         remaining_cal = Calendar.query.filter_by(ical_url=SAMPLE_V2).first()
         assert remaining_cal is not None
         assert Event.query.filter_by(ical_id=remaining_cal.id).count() > 0
+
+    # -- empty / unusable feed error handling --
+
+    def test_fetch_empty_feed_raises_ical_feed_error(self):
+        # A 200 response with no body must raise IcalFeedError, not fall through
+        # to the opaque icalendar parser error.
+        with patch('services.ical.requests.get', return_value=_FakeResponse([])):
+            with self.assertRaises(IcalFeedError) as ctx:
+                fetch_ical_events('https://example.com/empty.ics')
+        assert 'empty' in str(ctx.exception).lower()
+
+    def test_fetch_whitespace_only_feed_raises(self):
+        # Whitespace-only bodies are just as unusable as truly empty ones.
+        with patch('services.ical.requests.get', return_value=_FakeResponse([b'  \r\n\t '])):
+            with self.assertRaises(IcalFeedError):
+                fetch_ical_events('https://example.com/blank.ics')
+
+    def test_import_empty_feed_returns_friendly_error(self):
+        # import_ical should surface the clear message, NOT the raw parser text.
+        user_id = User.query.filter_by(username='gerald').first().id
+        with patch('services.ical.validate_url', return_value=None), \
+             patch('services.ical.requests.get', return_value=_FakeResponse([])):
+            result, error = import_ical('https://example.com/empty.ics', user_id)
+        assert result is None
+        assert error is not None
+        assert 'empty' in error.lower()
+        # Must not leak the internal parser error or the generic parse prefix.
+        assert 'Found no components' not in error
+        assert 'could not parse' not in error.lower()
+
+    def test_import_endpoint_empty_feed_returns_400(self):
+        # End-to-end through the API route, network mocked.
+        with patch('services.ical.validate_url', return_value=None), \
+             patch('services.ical.requests.get', return_value=_FakeResponse([])):
+            response = self.client.post('/api/import-ical/', json={"url": "https://example.com/empty.ics"})
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'error' in data
+        assert 'empty' in data['error'].lower()
+
+    def test_import_malformed_feed_still_reports_parse_error(self):
+        # Non-empty but junk content should still hit the generic parse branch,
+        # confirming we didn't swallow real parse failures.
+        with patch('services.ical.validate_url', return_value=None), \
+             patch('services.ical.requests.get', return_value=_FakeResponse([b'this is not ical'])):
+            user_id = User.query.filter_by(username='gerald').first().id
+            result, error = import_ical('https://example.com/junk.ics', user_id)
+        assert result is None
+        assert error is not None
+        assert 'parse' in error.lower()


### PR DESCRIPTION
Fixes the confusing error you get when a CAS link is dead. A stale/expired link returns a 200 with an empty body, which fell through to the raw icalendar parser error ("Found no components where exactly one is required: b''").

Now we catch the empty (or whitespace only) feed before parsing and return a clear message instead - "The iCal feed was empty, check that the link is correct and still active". Same treatment for the too-large case. Genuine parse errors on real content are untouched.

Added a few tests for the empty/whitespace cases, the import function and the api endpoint. All network mocked so no external calls.